### PR TITLE
Change code so buying time is actually sunday

### DIFF
--- a/public/good.html
+++ b/public/good.html
@@ -185,7 +185,7 @@
         dateString = $("#DatePicker").val();
         var selectedDate = new Date(dateString);
         console.log('selected day: ' + selectedDate.getDay());
-        if(selectedDate.getDay() == 6) {
+        if(selectedDate.getDay() == 0) {
           time = 2;
           $("#buySellTag").html("Buy");
           $("#buySellTag").removeClass("badge-success");


### PR DESCRIPTION
The app is currently showing Saturday as the buying day for turnips.
![image](https://user-images.githubusercontent.com/20229636/79323523-98ea8f00-7f0e-11ea-8d08-15db46283445.png)
In that screenshot we can see the April month and we can see that the app seems to think Saturday is the buying time.

getDay will return the week number assuming Sunday is the first day of the week, so we should check against 0.